### PR TITLE
Use airflow variables if available

### DIFF
--- a/build_stac/handler.py
+++ b/build_stac/handler.py
@@ -5,8 +5,7 @@ from typing import Any, Dict, TypedDict, Union
 from uuid import uuid4
 
 import smart_open
-
-from utils import stac, events
+from utils import events, stac
 
 
 class S3LinkOutput(TypedDict):

--- a/build_stac/tests/conftest.py
+++ b/build_stac/tests/conftest.py
@@ -1,11 +1,10 @@
 import os
 from unittest import mock
 
-import pytest
 import boto3
+import pytest
 from moto import mock_s3
-
-from mypy_boto3_s3.service_resource import S3ServiceResource, Bucket
+from mypy_boto3_s3.service_resource import Bucket, S3ServiceResource
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/build_stac/tests/test_handler.py
+++ b/build_stac/tests/test_handler.py
@@ -1,13 +1,12 @@
 import contextlib
 from typing import TYPE_CHECKING, Any, Dict, Type
 from unittest.mock import MagicMock, Mock
-from pydantic import ValidationError
-
-import pytest
-from pystac import Item
 
 import handler
-from utils import stac, events
+import pytest
+from pydantic import ValidationError
+from pystac import Item
+from utils import events, stac
 
 if TYPE_CHECKING:
     from functools import _SingleDispatchCallable

--- a/build_stac/tests/test_regex.py
+++ b/build_stac/tests/test_regex.py
@@ -1,8 +1,7 @@
-import pytest
-
 from datetime import datetime, timezone
 
-from utils import regex, events
+import pytest
+from utils import events, regex
 
 
 @pytest.mark.parametrize(

--- a/build_stac/utils/events.py
+++ b/build_stac/utils/events.py
@@ -1,12 +1,12 @@
-from datetime import datetime
-from typing import Dict, List, Literal, Optional, Union
-from pathlib import Path
 import re
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Union
+
+import pystac
+from pydantic import BaseModel, Field
 
 from .provider import Provider
-from pydantic import BaseModel, Field
-import pystac
-
 
 INTERVAL = Literal["month", "year"]
 

--- a/build_stac/utils/provider.py
+++ b/build_stac/utils/provider.py
@@ -1,8 +1,8 @@
-from enum import Enum
 from datetime import datetime
+from enum import Enum
 from typing import List
 
-from pydantic import BaseModel, AnyUrl
+from pydantic import AnyUrl, BaseModel
 
 
 class ProviderRole(str, Enum):

--- a/build_stac/utils/regex.py
+++ b/build_stac/utils/regex.py
@@ -1,10 +1,10 @@
 import re
-from typing import Callable, Dict, Tuple, Union
 from datetime import datetime, timezone
+from typing import Callable, Dict, Tuple, Union
+
 from dateutil.relativedelta import relativedelta
 
 from . import events
-
 
 DATERANGE = Tuple[datetime, datetime]
 

--- a/build_stac/utils/stac.py
+++ b/build_stac/utils/stac.py
@@ -1,17 +1,15 @@
 import os
-
-from pathlib import Path
 from functools import singledispatch
+from pathlib import Path
 
 import pystac
 import rasterio
-
 from cmr import GranuleQuery
 from pystac.utils import str_to_datetime
-from rio_stac import stac
 from rasterio.session import AWSSession
+from rio_stac import stac
 
-from . import regex, events, role
+from . import events, regex, role
 
 
 def create_item(

--- a/cmr_query/handler.py
+++ b/cmr_query/handler.py
@@ -1,6 +1,5 @@
-import re
-
 import datetime as dt
+import re
 
 from cmr import GranuleQuery
 

--- a/cogify/handler.py
+++ b/cogify/handler.py
@@ -1,11 +1,9 @@
 import configparser
 import os
-import requests
 
 import boto3
-
 import numpy as np
-
+import requests
 from affine import Affine
 from netCDF4 import Dataset
 from rasterio.crs import CRS
@@ -13,7 +11,6 @@ from rasterio.io import MemoryFile
 from rasterio.warp import calculate_default_transform
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
-
 
 config = {
     "DEFAULT": {"output_bucket": "climatedashboard-data", "output_dir": "OMDOAO3e_003"},

--- a/data_transfer/conftest.py
+++ b/data_transfer/conftest.py
@@ -1,11 +1,10 @@
 import os
 from unittest import mock
 
-import pytest
 import boto3
+import pytest
 from moto import mock_s3
-
-from mypy_boto3_s3.service_resource import S3ServiceResource, Bucket
+from mypy_boto3_s3.service_resource import Bucket, S3ServiceResource
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/data_transfer/handler.py
+++ b/data_transfer/handler.py
@@ -1,6 +1,6 @@
 import os
-import urllib.parse
 import tempfile
+import urllib.parse
 
 import boto3
 from botocore.errorfactory import ClientError

--- a/proxy/handler.py
+++ b/proxy/handler.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 import boto3
 

--- a/s3_discovery/handler.py
+++ b/s3_discovery/handler.py
@@ -1,9 +1,9 @@
-import re
-import boto3
 import json
 import os
+import re
 from uuid import uuid4
 
+import boto3
 from smart_open import open as smrt_open
 
 

--- a/s3_discovery/handler.py
+++ b/s3_discovery/handler.py
@@ -76,7 +76,7 @@ def generate_payload(s3_prefix_key: str, payload: dict, limit: int = None):
     return output_key
 
 
-def s3_discovery_handler(event, chunk_size=2800):
+def s3_discovery_handler(event, chunk_size=2800, role_arn=None, bucket_output=None):
     bucket = event.get("bucket")
     prefix = event.get("prefix", "")
     filename_regex = event.get("filename_regex", None)
@@ -96,14 +96,14 @@ def s3_discovery_handler(event, chunk_size=2800):
     if "datetime_range" in event:
         date_fields["datetime_range"] = event["datetime_range"]
 
-    role_arn = os.environ.get("ASSUME_ROLE_ARN")
+    role_arn = os.environ.get("ASSUME_ROLE_ARN", role_arn)
     kwargs = assume_role(role_arn=role_arn) if role_arn else {}
     s3client = boto3.client("s3", **kwargs)
 
     s3_iterator = get_s3_resp_iterator(
         bucket_name=bucket, prefix=prefix, s3_client=s3client
     )
-    bucket_output = os.environ.get("EVENT_BUCKET")
+    bucket_output = os.environ.get("EVENT_BUCKET", bucket_output)
     key = f"s3://{bucket_output}/events/{collection}"
     records = 0
     out_keys = []

--- a/submit_stac/handler.py
+++ b/submit_stac/handler.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass
 import json
 import os
-from urllib.parse import urlparse
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, TypedDict, Union
+from urllib.parse import urlparse
 
 import boto3
 import requests


### PR DESCRIPTION
This PR enables us to fall back to manually provided variables in cases where `os.environ` can't be conveniently populated